### PR TITLE
binary mode fixes & k3s version bump

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,5 +1,5 @@
 ---
 k3s::ensure: 'present'
 k3s::installation_mode: 'script'
-k3s::binary_version: 'v1.18.8'
+k3s::binary_version: 'v1.19.4+k3s1'
 k3s::binary_path: '/usr/bin/k3s'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,7 @@ class k3s (
 ) {
   if $installation_mode == 'binary' and (!$binary_path or !$binary_version) {
     fail('The vars $binary_version and $binary_path must be set when using the \
-      script installation mode.')
+      binary installation mode.')
   }
 
   if $ensure == 'present' {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -48,8 +48,8 @@ class k3s::install {
           fail('No valid architecture provided.')
         }
       }
-      $k3s_url = "https://github.com/rancher/k3s/releases/download/${k3s::binary_version}+k3s1/${binary_arch}"
-      $k3s_checksum_url = "https://github.com/rancher/k3s/releases/download/${k3s::binary_version}+k3s1/${checksum_arch}"
+      $k3s_url = "https://github.com/rancher/k3s/releases/download/${k3s::binary_version}/${binary_arch}"
+      $k3s_checksum_url = "https://github.com/rancher/k3s/releases/download/${k3s::binary_version}/${checksum_arch}"
 
       archive { $k3s::binary_path:
         ensure           => present,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -56,6 +56,7 @@ class k3s::install {
         source           => $k3s_url,
         checksum_url     => $k3s_checksum_url,
         checksum_type    => 'sha256',
+        cleanup          => false,
         creates          => $k3s::binary_path,
         download_options => '-S',
       }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -63,7 +63,7 @@ class k3s::install {
 
       file { $k3s::binary_path:
         ensure  => file,
-        mode    => '0775',
+        mode    => '0755',
         require => [
           Archive[$k3s::binary_path],
         ],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -32,7 +32,7 @@ class k3s::install {
 
     'binary': {
       case $facts['os']['architecture'] {
-        'amd64': {
+        'amd64', 'x86_64': {
           $binary_arch = 'k3s'
           $checksum_arch = 'sha256sum-amd64.txt'
         }


### PR DESCRIPTION
* Correct mode in fail() message for binary_version missing
* Fedora os.architecture is x86_64, equivalent to amd64 (ref: https://puppet.com/docs/facter/3.11/core_facts.html#architecture)
* Bump to latest k3s version (v1.19.4+k3s1)
* Don't hardcode k3s1 version suffix in install.pp (it can vary; see https://github.com/rancher/k3s/releases)
* disable archive cleanup, it removes binary_path